### PR TITLE
Make edit async

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -22,7 +22,7 @@ foreach ($platform in "ARM64", "x64")
     dotnet build $projectDirectory.sln -c Release /p:Platform=$platform
 
     $releaseDirectory = "$projectDirectory\bin\$platform\Release"
-    Remove-Item -Path "$projectDirectory\bin\*" -Recurse -Include *.xml, *.pdb, PowerToys.*, Wox.*
+    Remove-Item -Path "$projectDirectory\bin\*" -Recurse -Include *.xml, *.pdb, PowerToys.*, Wox.*, WinRT*, Microsoft*
     New-Item -ItemType Directory -Force -Path $releaseDirectory\Paster
     Copy-Item -Path $pasterReleaseDirectory\* -Destination $releaseDirectory\Paster -Recurse
     Rename-Item -Path $releaseDirectory -NewName "ClipboardManager"

--- a/Build.ps1
+++ b/Build.ps1
@@ -24,7 +24,7 @@ foreach ($platform in "ARM64", "x64")
     $releaseDirectory = "$projectDirectory\bin\$platform\Release"
     Remove-Item -Path "$projectDirectory\bin\*" -Recurse -Include *.xml, *.pdb, PowerToys.*, Wox.*, WinRT*, Microsoft*
     New-Item -ItemType Directory -Force -Path $releaseDirectory\Paster
-    Copy-Item -Path $pasterReleaseDirectory\* -Destination $releaseDirectory\Paster -Recurse
+    Copy-Item -Path $pasterReleaseDirectory\Paster.exe -Destination $releaseDirectory\Paster -Recurse
     Rename-Item -Path $releaseDirectory -NewName "ClipboardManager"
 
     Compress-Archive -Path "$projectDirectory\bin\$platform\ClipboardManager" -DestinationPath "$PSScriptRoot\ClipboardManager-$version-$platform.zip"

--- a/Community.PowerToys.Run.Plugin.ClipboardManager/Main.cs
+++ b/Community.PowerToys.Run.Plugin.ClipboardManager/Main.cs
@@ -210,28 +210,31 @@ namespace Community.PowerToys.Run.Plugin.ClipboardManager
                     AcceleratorModifiers = ModifierKeys.Control,
                     Action = c =>
                     {
-                        _ = EditAsync(selectedResult);
+                        _ = EditAsync(selectedResult, _context);
 
                         return true;
 
-                        static async Task EditAsync(Result selectedResult)
+                        static async Task EditAsync(Result selectedResult, PluginInitContext context)
                         {
-                            var text = (string)selectedResult.ContextData;
-                            var tempFile = Path.GetTempFileName();
-                            File.WriteAllText(tempFile, text);
-                            Process process = new()
-                            {
-                                StartInfo =
+                            await Task.Run(() => {
+                                var text = (string)selectedResult.ContextData;
+                                var tempFile = Path.GetTempFileName();
+                                File.WriteAllText(tempFile, text);
+                                Process process = new()
                                 {
-                                    FileName = tempFile,
-                                    UseShellExecute = true,
-                                }
-                            };
-                            process.Start();
-                            process.WaitForExit();
+                                    StartInfo =
+                                    {
+                                        FileName = tempFile,
+                                        UseShellExecute = true,
+                                    }
+                                };
+                                process.Start();
+                                process.WaitForExit();
 
-                            ClipboardManager.SetStringAsClipboardContent(File.ReadAllText(tempFile));
-                            File.Delete(tempFile);
+                                ClipboardManager.SetStringAsClipboardContent(File.ReadAllText(tempFile));
+                                File.Delete(tempFile);
+                                context.API.ChangeQuery(context.CurrentPluginMetadata.ActionKeyword);
+                            });
                         }
                     }
                 }

--- a/Community.PowerToys.Run.Plugin.ClipboardManager/Main.cs
+++ b/Community.PowerToys.Run.Plugin.ClipboardManager/Main.cs
@@ -216,10 +216,10 @@ namespace Community.PowerToys.Run.Plugin.ClipboardManager
 
                         static async Task EditAsync(Result selectedResult, PluginInitContext context)
                         {
+                            var text = (string)selectedResult.ContextData;
+                            var tempFile = Path.GetTempFileName();
+                            File.WriteAllText(tempFile, text);
                             await Task.Run(() => {
-                                var text = (string)selectedResult.ContextData;
-                                var tempFile = Path.GetTempFileName();
-                                File.WriteAllText(tempFile, text);
                                 Process process = new()
                                 {
                                     StartInfo =
@@ -230,11 +230,10 @@ namespace Community.PowerToys.Run.Plugin.ClipboardManager
                                 };
                                 process.Start();
                                 process.WaitForExit();
-
-                                ClipboardManager.SetStringAsClipboardContent(File.ReadAllText(tempFile));
-                                File.Delete(tempFile);
-                                context.API.ChangeQuery(context.CurrentPluginMetadata.ActionKeyword);
                             });
+
+                            ClipboardManager.SetStringAsClipboardContent(File.ReadAllText(tempFile));
+                            File.Delete(tempFile);
                         }
                     }
                 }

--- a/Community.PowerToys.Run.Plugin.ClipboardManager/Main.cs
+++ b/Community.PowerToys.Run.Plugin.ClipboardManager/Main.cs
@@ -210,11 +210,11 @@ namespace Community.PowerToys.Run.Plugin.ClipboardManager
                     AcceleratorModifiers = ModifierKeys.Control,
                     Action = c =>
                     {
-                        _ = EditAsync(selectedResult, _context);
+                        _ = EditAsync(selectedResult);
 
                         return true;
 
-                        static async Task EditAsync(Result selectedResult, PluginInitContext context)
+                        static async Task EditAsync(Result selectedResult)
                         {
                             var text = (string)selectedResult.ContextData;
                             var tempFile = Path.GetTempFileName();


### PR DESCRIPTION
The refactor removes async part in `EditAsync`, so it's executed synchronously and PowerToys Run UI will block the edit window.

This PR also removes `Microsoft.Windows.SDK.NET.dll` and `WinRT.Runtime.dll` as they are already included in PowerToys, and only preserve `Paster.exe` in the `Paster` directory.